### PR TITLE
Add translate executable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in cw_translate.gemspec
 gemspec
-
-gem 'rationalist'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in cw_translate.gemspec
 gemspec
+
+gem 'rationalist'

--- a/bin/translate
+++ b/bin/translate
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift("#{__dir__}/../lib")
+
+require 'cw_translate'
+require 'rationalist'
+
+RATIONALIST_OPTIONS = {
+  alias: { from: 'f', to: 't' }
+}.freeze
+
+args = Rationalist.parse(ARGV, RATIONALIST_OPTIONS)
+cli = CwTranslate::CLI.new(args)

--- a/bin/translate
+++ b/bin/translate
@@ -10,4 +10,4 @@ RATIONALIST_OPTIONS = {
 }.freeze
 
 args = Rationalist.parse(ARGV, RATIONALIST_OPTIONS)
-cli = CwTranslate::CLI.new(args)
+CwTranslate::CLI.new(args)

--- a/cw_translate.gemspec
+++ b/cw_translate.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rationalist", "~> 2.0"
 end

--- a/lib/cw_translate.rb
+++ b/lib/cw_translate.rb
@@ -1,6 +1,7 @@
 require "cw_translate/version"
 require "cw_translate/cache"
 require "cw_translate/translator"
+require "cw_translate/cli"
 
 module CwTranslate
   DEFAULT_OPTIONS = {from: nil, translator: nil, no_cache: false}.freeze

--- a/lib/cw_translate/cli.rb
+++ b/lib/cw_translate/cli.rb
@@ -1,0 +1,10 @@
+module CwTranslate
+  class CLI
+    def initialize(options)
+      @text = options[:_].first
+      @options = options.tap { |opt| opt.delete(:_) }
+
+      CwTranslate.translate(@text, @options[:to])
+    end
+  end
+end

--- a/spec/cw_translate/cli_spec.rb
+++ b/spec/cw_translate/cli_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe CwTranslate::CLI do
+  subject { described_class.new(args) }
+
+  describe 'text and to argument are given' do
+    let(:args) { { _: [ 'hallo' ], to: 'en' } }
+
+    it 'calls CwTranslate.translate with correct arguments' do
+      expect(CwTranslate).to receive(:translate).with('hallo', 'en')
+      subject
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4 

For now I only implemented a basic version of the executable calling the `CwTranslate::CLI`.
As #5 introduces some changes I think it's better to rework this afterwards and then also add the documentation (--help command).